### PR TITLE
Add metrics in deit/Swin/RoBERTa

### DIFF
--- a/RoBERTa/fairseq.patch
+++ b/RoBERTa/fairseq.patch
@@ -163,7 +163,7 @@ index da1f9491..ec6e1732 100644
          self.last_device = None
          if self.cuda and self.pipeline_model_parallel:
 diff --git a/fairseq_cli/train.py b/fairseq_cli/train.py
-index 376bd1d0..2b10d49c 100644
+index 376bd1d0..75197bc0 100644
 --- a/fairseq_cli/train.py
 +++ b/fairseq_cli/train.py
 @@ -26,6 +26,7 @@ logger = logging.getLogger("fairseq_cli.train")
@@ -174,19 +174,14 @@ index 376bd1d0..2b10d49c 100644
  
  from fairseq import checkpoint_utils, options, quantization_utils, tasks, utils
  from fairseq.data import data_utils, iterators
-@@ -123,6 +124,21 @@ def main(cfg: FairseqConfig) -> None:
+@@ -123,6 +124,16 @@ def main(cfg: FairseqConfig) -> None:
          )
      )
  
 +    # compute model flops: create fake input and use fvcore to compute the model flops.
 +    tokens_per_sample = cfg.task.tokens_per_sample
 +    logger.info(f'tokens_per_sample: {tokens_per_sample}')
-+    token_ids = []
-+    token_ids.append(0)
-+
-+    for _ in range(tokens_per_sample - 2):
-+        token_ids.append(100)
-+    token_ids.append(2)
++    token_ids = [0] + [100] * (tokens_per_sample - 2) + [2]
 +    src_tokens = torch.tensor(token_ids).unsqueeze(0).cuda()
 +    with torch.no_grad():
 +        model.cuda()
@@ -196,7 +191,7 @@ index 376bd1d0..2b10d49c 100644
      # Load valid dataset (we load training data below, based on the latest checkpoint)
      # We load the valid dataset AFTER building the model
      data_utils.raise_if_valid_subsets_unintentionally_ignored(cfg)
-@@ -187,7 +203,7 @@ def main(cfg: FairseqConfig) -> None:
+@@ -187,7 +198,7 @@ def main(cfg: FairseqConfig) -> None:
              break
  
          # train for one epoch
@@ -205,7 +200,7 @@ index 376bd1d0..2b10d49c 100644
          if should_stop:
              break
  
-@@ -244,7 +260,7 @@ def should_stop_early(cfg: DictConfig, valid_loss: float) -> bool:
+@@ -244,7 +255,7 @@ def should_stop_early(cfg: DictConfig, valid_loss: float) -> bool:
  
  @metrics.aggregate("train")
  def train(
@@ -214,14 +209,14 @@ index 376bd1d0..2b10d49c 100644
  ) -> Tuple[List[Optional[float]], bool]:
      """Train the model for one epoch and return validation losses."""
      # Initialize data iterator
-@@ -320,6 +336,12 @@ def train(
+@@ -320,6 +331,12 @@ def train(
              num_updates = trainer.get_num_updates()
              if num_updates % cfg.common.log_interval == 0:
                  stats = get_training_stats(metrics.get_smoothed_values("train_inner"))
 +                throughput = stats["bsz"] * stats["ups"]
 +                stats["throughput"] = throughput
 +                throughput_per_gpu = throughput / cfg.distributed_training.distributed_world_size
-+                # The reason of x 3: 1 forward + 2 backward. The reason of x 2: 1MACC = 2FLOPS
++                # The reason of x 3: 1 forward + 2 backward. The reason of x 2: 1MACs = 2FLOPs
 +                stats["tflops"] = throughput_per_gpu * 3 * 2 * model_flops / 1e12
 +
                  progress.log(stats, tag="train_inner", step=num_updates)

--- a/RoBERTa/fairseq.patch
+++ b/RoBERTa/fairseq.patch
@@ -162,6 +162,71 @@ index da1f9491..ec6e1732 100644
          self.pipeline_model_parallel = cfg.distributed_training.pipeline_model_parallel
          self.last_device = None
          if self.cuda and self.pipeline_model_parallel:
+diff --git a/fairseq_cli/train.py b/fairseq_cli/train.py
+index 376bd1d0..2b10d49c 100644
+--- a/fairseq_cli/train.py
++++ b/fairseq_cli/train.py
+@@ -26,6 +26,7 @@ logger = logging.getLogger("fairseq_cli.train")
+ import numpy as np
+ import torch
+ from omegaconf import DictConfig, OmegaConf
++from fvcore.nn import FlopCountAnalysis
+ 
+ from fairseq import checkpoint_utils, options, quantization_utils, tasks, utils
+ from fairseq.data import data_utils, iterators
+@@ -123,6 +124,21 @@ def main(cfg: FairseqConfig) -> None:
+         )
+     )
+ 
++    # compute model flops: create fake input and use fvcore to compute the model flops.
++    tokens_per_sample = cfg.task.tokens_per_sample
++    logger.info(f'tokens_per_sample: {tokens_per_sample}')
++    token_ids = []
++    token_ids.append(0)
++
++    for _ in range(tokens_per_sample - 2):
++        token_ids.append(100)
++    token_ids.append(2)
++    src_tokens = torch.tensor(token_ids).unsqueeze(0).cuda()
++    with torch.no_grad():
++        model.cuda()
++        model_flops = FlopCountAnalysis(model, src_tokens).total()
++    logger.info(f'model flops: {model_flops}')
++
+     # Load valid dataset (we load training data below, based on the latest checkpoint)
+     # We load the valid dataset AFTER building the model
+     data_utils.raise_if_valid_subsets_unintentionally_ignored(cfg)
+@@ -187,7 +203,7 @@ def main(cfg: FairseqConfig) -> None:
+             break
+ 
+         # train for one epoch
+-        valid_losses, should_stop = train(cfg, trainer, task, epoch_itr)
++        valid_losses, should_stop = train(cfg, trainer, task, epoch_itr, model_flops)
+         if should_stop:
+             break
+ 
+@@ -244,7 +260,7 @@ def should_stop_early(cfg: DictConfig, valid_loss: float) -> bool:
+ 
+ @metrics.aggregate("train")
+ def train(
+-    cfg: DictConfig, trainer: Trainer, task: tasks.FairseqTask, epoch_itr
++    cfg: DictConfig, trainer: Trainer, task: tasks.FairseqTask, epoch_itr, model_flops=0
+ ) -> Tuple[List[Optional[float]], bool]:
+     """Train the model for one epoch and return validation losses."""
+     # Initialize data iterator
+@@ -320,6 +336,12 @@ def train(
+             num_updates = trainer.get_num_updates()
+             if num_updates % cfg.common.log_interval == 0:
+                 stats = get_training_stats(metrics.get_smoothed_values("train_inner"))
++                throughput = stats["bsz"] * stats["ups"]
++                stats["throughput"] = throughput
++                throughput_per_gpu = throughput / cfg.distributed_training.distributed_world_size
++                # The reason of x 3: 1 forward + 2 backward. The reason of x 2: 1MACC = 2FLOPS
++                stats["tflops"] = throughput_per_gpu * 3 * 2 * model_flops / 1e12
++
+                 progress.log(stats, tag="train_inner", step=num_updates)
+ 
+                 # reset mid-epoch stats after each log interval
 diff --git a/setup.py b/setup.py
 index 8a9b2f97..1bc5650d 100644
 --- a/setup.py

--- a/RoBERTa/run.sh
+++ b/RoBERTa/run.sh
@@ -20,11 +20,7 @@ fairseq_train=`which fairseq-hydra-train`
 if [ "$amp_type" = "amp" ]; then
     echo "run RoBERTa base with AMP"
     SAVE_PATH=$PWD/checkpoints/roberta_amp/
-
-    python -m torch.distributed.launch \
-        --use_env \
-        --nproc_per_node=$GPU_NUM \
-        $fairseq_train \
+    $fairseq_train \
         --config-dir ../third_party/fairseq/examples/roberta/config/pretraining \
         --config-name base  \
         task.data=$DATA_PATH \
@@ -37,15 +33,13 @@ if [ "$amp_type" = "amp" ]; then
         checkpoint.save_interval_updates=500 \
         common.log_interval=20 \
         dataset.validate_interval_updates=500 \
-        distributed_training.ddp_backend=c10d
+        distributed_training.ddp_backend=c10d \
+        distributed_training.distributed_world_size=$GPU_NUM
 
 elif [ "$amp_type" = "msamp" ]; then
     echo "run RoBERTa base with MS-AMP"
     SAVE_PATH=$PWD/checkpoints/roberta_msamp/
-    python -m torch.distributed.launch \
-        --use_env \
-        --nproc_per_node=$GPU_NUM \
-        $fairseq_train \
+    $fairseq_train \
         --config-dir ../third_party/fairseq/examples/roberta/config/pretraining \
         --config-name base  \
         task.data=$DATA_PATH \
@@ -60,7 +54,8 @@ elif [ "$amp_type" = "msamp" ]; then
         dataset.validate_interval_updates=500 \
         common.msamp=True \
         common.msamp_opt_level=O2 \
-        distributed_training.ddp_backend=c10d
+        distributed_training.ddp_backend=c10d \
+        distributed_training.distributed_world_size=$GPU_NUM
 else
     echo $USAGE
     exit 1

--- a/Swin-Transformer/Swin-Transformer.patch
+++ b/Swin-Transformer/Swin-Transformer.patch
@@ -49,7 +49,7 @@ index 0000000..67b4476
 +    WINDOW_SIZE: 7
 \ No newline at end of file
 diff --git a/main.py b/main.py
-index 84230ea..d459965 100644
+index 84230ea..72cb858 100644
 --- a/main.py
 +++ b/main.py
 @@ -19,6 +19,7 @@ import torch.distributed as dist
@@ -99,7 +99,18 @@ index 84230ea..d459965 100644
      config = get_config(args)
  
      return args, config
-@@ -95,9 +109,22 @@ def main(config):
+@@ -87,6 +101,10 @@ def main(config):
+     logger.info(f"Creating model:{config.MODEL.TYPE}/{config.MODEL.NAME}")
+     model = build_model(config)
+     logger.info(str(model))
++    
++    # get flops of the model.
++    flops = model.flops()
++    args.flops = flops
+ 
+     n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
+     logger.info(f"number of params: {n_parameters}")
+@@ -95,9 +113,22 @@ def main(config):
          logger.info(f"number of GFLOPs: {flops / 1e9}")
  
      model.cuda()
@@ -122,7 +133,7 @@ index 84230ea..d459965 100644
      model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[config.LOCAL_RANK], broadcast_buffers=False)
      loss_scaler = NativeScalerWithGradNormCount()
  
-@@ -177,6 +204,8 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
+@@ -177,6 +208,8 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
  
      start = time.time()
      end = time.time()
@@ -131,7 +142,7 @@ index 84230ea..d459965 100644
      for idx, (samples, targets) in enumerate(data_loader):
          samples = samples.cuda(non_blocking=True)
          targets = targets.cuda(non_blocking=True)
-@@ -184,14 +213,14 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
+@@ -184,14 +217,14 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
          if mixup_fn is not None:
              samples, targets = mixup_fn(samples, targets)
  
@@ -148,7 +159,34 @@ index 84230ea..d459965 100644
                                  parameters=model.parameters(), create_graph=is_second_order,
                                  update_grad=(idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0)
          if (idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0:
-@@ -236,12 +265,13 @@ def validate(config, data_loader, model):
+@@ -207,19 +240,25 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
+         scaler_meter.update(loss_scale_value)
+         batch_time.update(time.time() - end)
+         end = time.time()
+-
++        throughput = args.batch_size / batch_time.val
++        throughput_avg = args.batch_size / batch_time.avg
+         if idx % config.PRINT_FREQ == 0:
+             lr = optimizer.param_groups[0]['lr']
+             wd = optimizer.param_groups[0]['weight_decay']
+             memory_used = torch.cuda.max_memory_allocated() / (1024.0 * 1024.0)
+             etas = batch_time.avg * (num_steps - idx)
++            ratio = 3 if config.TRAIN.USE_CHECKPOINT else 4
++            # First mutiply by ratio: 1 for forward, 2 for backward, 1 for activation checkpoint. Then multiply by 2: 1MACs = 2FLOPs
++            tflops = ratio * 2 * args.flops * throughput / 1e12
+             logger.info(
+                 f'Train: [{epoch}/{config.TRAIN.EPOCHS}][{idx}/{num_steps}]\t'
+                 f'eta {datetime.timedelta(seconds=int(etas))} lr {lr:.6f}\t wd {wd:.4f}\t'
+                 f'time {batch_time.val:.4f} ({batch_time.avg:.4f})\t'
++                f'throughput {throughput:.2f} ({throughput_avg: .2f})\t'
+                 f'loss {loss_meter.val:.4f} ({loss_meter.avg:.4f})\t'
+                 f'grad_norm {norm_meter.val:.4f} ({norm_meter.avg:.4f})\t'
+                 f'loss_scale {scaler_meter.val:.4f} ({scaler_meter.avg:.4f})\t'
++                f'tflops {tflops:.2f}\t'
+                 f'mem {memory_used:.0f}MB')
+     epoch_time = time.time() - start
+     logger.info(f"EPOCH {epoch} training takes {datetime.timedelta(seconds=int(epoch_time))}")
+@@ -236,12 +275,13 @@ def validate(config, data_loader, model):
      acc5_meter = AverageMeter()
  
      end = time.time()

--- a/Swin-Transformer/Swin-Transformer.patch
+++ b/Swin-Transformer/Swin-Transformer.patch
@@ -49,7 +49,7 @@ index 0000000..67b4476
 +    WINDOW_SIZE: 7
 \ No newline at end of file
 diff --git a/main.py b/main.py
-index 84230ea..72cb858 100644
+index 84230ea..61aa366 100644
 --- a/main.py
 +++ b/main.py
 @@ -19,6 +19,7 @@ import torch.distributed as dist
@@ -99,17 +99,17 @@ index 84230ea..72cb858 100644
      config = get_config(args)
  
      return args, config
-@@ -87,6 +101,10 @@ def main(config):
-     logger.info(f"Creating model:{config.MODEL.TYPE}/{config.MODEL.NAME}")
+@@ -88,6 +102,10 @@ def main(config):
      model = build_model(config)
      logger.info(str(model))
-+    
+ 
 +    # get flops of the model.
 +    flops = model.flops()
 +    args.flops = flops
- 
++
      n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
      logger.info(f"number of params: {n_parameters}")
+     if hasattr(model, 'flops'):
 @@ -95,9 +113,22 @@ def main(config):
          logger.info(f"number of GFLOPs: {flops / 1e9}")
  

--- a/Swin-Transformer/Swin-Transformer.patch
+++ b/Swin-Transformer/Swin-Transformer.patch
@@ -49,7 +49,7 @@ index 0000000..67b4476
 +    WINDOW_SIZE: 7
 \ No newline at end of file
 diff --git a/main.py b/main.py
-index 84230ea..61aa366 100644
+index 84230ea..a40369e 100644
 --- a/main.py
 +++ b/main.py
 @@ -19,6 +19,7 @@ import torch.distributed as dist
@@ -104,8 +104,8 @@ index 84230ea..61aa366 100644
      logger.info(str(model))
  
 +    # get flops of the model.
-+    flops = model.flops()
-+    args.flops = flops
++    model_flops = model.flops()
++    args.model_flops = model_flops
 +
      n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
      logger.info(f"number of params: {n_parameters}")
@@ -159,13 +159,14 @@ index 84230ea..61aa366 100644
                                  parameters=model.parameters(), create_graph=is_second_order,
                                  update_grad=(idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0)
          if (idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0:
-@@ -207,19 +240,25 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
+@@ -207,19 +240,26 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
          scaler_meter.update(loss_scale_value)
          batch_time.update(time.time() - end)
          end = time.time()
 -
-+        throughput = args.batch_size / batch_time.val
-+        throughput_avg = args.batch_size / batch_time.avg
++        throughput_per_gpu = args.batch_size / batch_time.val
++        throughput = dist.get_world_size() * throughput_per_gpu
++        throughput_avg = dist.get_world_size() * args.batch_size / batch_time.avg
          if idx % config.PRINT_FREQ == 0:
              lr = optimizer.param_groups[0]['lr']
              wd = optimizer.param_groups[0]['weight_decay']
@@ -173,7 +174,7 @@ index 84230ea..61aa366 100644
              etas = batch_time.avg * (num_steps - idx)
 +            ratio = 3 if config.TRAIN.USE_CHECKPOINT else 4
 +            # First mutiply by ratio: 1 for forward, 2 for backward, 1 for activation checkpoint. Then multiply by 2: 1MACs = 2FLOPs
-+            tflops = ratio * 2 * args.flops * throughput / 1e12
++            tflops = ratio * 2 * args.model_flops * throughput_per_gpu / 1e12
              logger.info(
                  f'Train: [{epoch}/{config.TRAIN.EPOCHS}][{idx}/{num_steps}]\t'
                  f'eta {datetime.timedelta(seconds=int(etas))} lr {lr:.6f}\t wd {wd:.4f}\t'
@@ -186,7 +187,7 @@ index 84230ea..61aa366 100644
                  f'mem {memory_used:.0f}MB')
      epoch_time = time.time() - start
      logger.info(f"EPOCH {epoch} training takes {datetime.timedelta(seconds=int(epoch_time))}")
-@@ -236,12 +275,13 @@ def validate(config, data_loader, model):
+@@ -236,12 +276,13 @@ def validate(config, data_loader, model):
      acc5_meter = AverageMeter()
  
      end = time.time()

--- a/common/stat_communication.py
+++ b/common/stat_communication.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import subprocess
+import glob
+import time
+import os
+import sys
+import argparse
+
+
+def get_ib_bandwidth():
+    """Get the infiniband bandwidth."""
+    # check if IB is avaiable.
+    output = os.popen('ibstat').read()
+    if 'CA type: ' not in output:
+        print('ib is not avaiable')
+        return
+
+    # Read the value from Infiniband counter files.
+    ib_counter_file="/sys/class/infiniband/mlx5_ib*/ports/1/counters/port_*_data"
+    prev_sum = 0
+    while True:
+        current_sum = 0
+        file_count = 0
+        for file_path in glob.glob(ib_counter_file):
+            file_count += 1
+            with open(file_path, 'r') as f:
+                current_value=int(f.read().strip())
+                current_sum += current_value
+        if file_count == 0:
+            print(f'there is no file match {ib_counter_file}, please check')
+            return
+
+        if prev_sum != 0:
+            ib_bandwidth = current_sum - prev_sum
+            print(f'infiniband bandwidth:{ib_bandwidth/1e9:.2f} GB')
+
+        prev_sum = current_sum
+        time.sleep(1)
+
+
+def get_nvlink_bandwidth():
+    """Get the nvlink bandwidth."""
+    # Get the number of GPUs on this machine
+    process = subprocess.Popen(['nvidia-smi', '-L'], stdout=subprocess.PIPE)
+    num_gpus = 0
+    for line in process.stdout:
+        line_str = line.decode().strip()
+        if line_str.startswith('GPU'):
+            num_gpus += 1
+    print(f'num_gpus:{num_gpus}')
+
+    # Run the command and compute nvlink bandwidth.
+    process = subprocess.Popen(['dcgmi', 'dmon', '-e', '1011,1012'], stdout=subprocess.PIPE)
+
+    gpu_ids = []
+    nvlink_bandwidth=0
+
+    for line in process.stdout:
+        line_str = line.decode().strip()
+        if not line_str.startswith('GPU'):
+            continue
+        arr = line_str.split()
+        gpu_id = arr[1]
+        gpu_ids.append(gpu_id)
+
+        if arr[2] != 'N/A':
+            nvlink_bandwidth += int(arr[2])
+        if arr[3] != 'N/A':
+            nvlink_bandwidth += int(arr[3])
+        if len(gpu_ids) == num_gpus:
+            print(f"nvlink bandwidth:{nvlink_bandwidth/1e9:.2f} GB")
+            gpu_ids.clear()
+            nvlink_bandwidth = 0
+
+
+def main():
+    """The entry point function."""
+    parser = argparse.ArgumentParser(description='stat communication')
+    parser.add_argument('--ib', action='store_true', help='stat infiniband bandwidth')
+    parser.add_argument('--nvlink', action='store_true', help='stat nvlink bandwidth')
+
+    args = parser.parse_args()
+    if args.ib:
+        get_ib_bandwidth()
+    elif args.nvlink:
+        get_nvlink_bandwidth()
+    else:
+        print('please specify --ib or --nvlink')
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/deit/deit.patch
+++ b/deit/deit.patch
@@ -1,5 +1,5 @@
 diff --git a/engine.py b/engine.py
-index ed10cea..e896068 100644
+index ed10cea..76665ef 100644
 --- a/engine.py
 +++ b/engine.py
 @@ -15,6 +15,9 @@ from timm.utils import accuracy, ModelEma
@@ -12,13 +12,19 @@ index ed10cea..e896068 100644
  
  def train_one_epoch(model: torch.nn.Module, criterion: DistillationLoss,
                      data_loader: Iterable, optimizer: torch.optim.Optimizer,
-@@ -27,6 +30,9 @@ def train_one_epoch(model: torch.nn.Module, criterion: DistillationLoss,
+@@ -22,11 +25,14 @@ def train_one_epoch(model: torch.nn.Module, criterion: DistillationLoss,
+                     model_ema: Optional[ModelEma] = None, mixup_fn: Optional[Mixup] = None,
+                     set_training_mode=True, args = None):
+     model.train(set_training_mode)
+-    metric_logger = utils.MetricLogger(delimiter="  ")
++    metric_logger = utils.MetricLogger(delimiter="  ", flops=args.flops)
+     metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value:.6f}'))
      header = 'Epoch: [{}]'.format(epoch)
      print_freq = 10
  
 +    # amp_enable, fp8_enable, fp8_format='hybrid', max_history_len=1, amax_compute_algo='max'
 +    autocast_context = TeUtils.get_autocast(True, args.enable_te_fp8)
-+
++    
      for samples, targets in metric_logger.log_every(data_loader, print_freq, header):
          samples = samples.to(device, non_blocking=True)
          targets = targets.to(device, non_blocking=True)
@@ -66,7 +72,7 @@ index ed10cea..e896068 100644
              loss = criterion(output, target)
  
 diff --git a/main.py b/main.py
-index bc8c418..588eaba 100644
+index bc8c418..98de2a9 100644
 --- a/main.py
 +++ b/main.py
 @@ -15,7 +15,9 @@ from timm.models import create_model
@@ -80,7 +86,7 @@ index bc8c418..588eaba 100644
  
  from datasets import build_dataset
  from engine import train_one_epoch, evaluate
-@@ -28,6 +30,11 @@ import models_v2
+@@ -28,6 +30,12 @@ import models_v2
  
  import utils
  
@@ -88,11 +94,12 @@ index bc8c418..588eaba 100644
 +import sys
 +sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../'))
 +
++from fvcore.nn import FlopCountAnalysis
 +from common.te_utils import replace_with_telinear
  
  def get_args_parser():
      parser = argparse.ArgumentParser('DeiT training and evaluation script', add_help=False)
-@@ -181,6 +188,13 @@ def get_args_parser():
+@@ -181,6 +189,13 @@ def get_args_parser():
      parser.add_argument('--world_size', default=1, type=int,
                          help='number of distributed processes')
      parser.add_argument('--dist_url', default='env://', help='url used to set up distributed training')
@@ -106,16 +113,29 @@ index bc8c418..588eaba 100644
      return parser
  
  
-@@ -266,6 +280,8 @@ def main(args):
+@@ -205,6 +220,8 @@ def main(args):
+     dataset_train, args.nb_classes = build_dataset(is_train=True, args=args)
+     dataset_val, _ = build_dataset(is_train=False, args=args)
+ 
++    first_image = dataset_train[0][0]
++
+     if True:  # args.distributed:
+         num_tasks = utils.get_world_size()
+         global_rank = utils.get_rank()
+@@ -266,6 +283,12 @@ def main(args):
          img_size=args.input_size
      )
  
++    input = first_image.unsqueeze(0)
++    flops = FlopCountAnalysis(model, input).total()
++    args.flops = flops
++
 +    if args.enable_msamp or args.enable_te_fp8:
 +        model.head.use_fp32_linear = True
                      
      if args.finetune:
          if args.finetune.startswith('https'):
-@@ -336,17 +352,33 @@ def main(args):
+@@ -336,17 +359,33 @@ def main(args):
              device='cpu' if args.model_ema_force_cpu else '',
              resume='')
  
@@ -154,7 +174,7 @@ index bc8c418..588eaba 100644
  
      lr_scheduler, _ = create_scheduler(args, optimizer)
  
-@@ -406,7 +438,7 @@ def main(args):
+@@ -406,7 +445,7 @@ def main(args):
                  loss_scaler.load_state_dict(checkpoint['scaler'])
          lr_scheduler.step(args.start_epoch)
      if args.eval:
@@ -163,7 +183,7 @@ index bc8c418..588eaba 100644
          print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
          return
  
-@@ -434,13 +466,13 @@ def main(args):
+@@ -434,13 +473,13 @@ def main(args):
                      'optimizer': optimizer.state_dict(),
                      'lr_scheduler': lr_scheduler.state_dict(),
                      'epoch': epoch,
@@ -179,7 +199,7 @@ index bc8c418..588eaba 100644
          print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
          
          if max_accuracy < test_stats["acc1"]:
-@@ -453,7 +485,7 @@ def main(args):
+@@ -453,7 +492,7 @@ def main(args):
                          'optimizer': optimizer.state_dict(),
                          'lr_scheduler': lr_scheduler.state_dict(),
                          'epoch': epoch,
@@ -251,3 +271,67 @@ index 0000000..dba0819
 +    def load_state_dict(self, state_dict):
 +        self._scaler.load_state_dict(state_dict)
 \ No newline at end of file
+diff --git a/utils.py b/utils.py
+index d1064f6..67d02eb 100644
+--- a/utils.py
++++ b/utils.py
+@@ -14,7 +14,6 @@ import datetime
+ import torch
+ import torch.distributed as dist
+ 
+-
+ class SmoothedValue(object):
+     """Track a series of values and provide access to smoothed values over a
+     window or the global series average.
+@@ -78,9 +77,10 @@ class SmoothedValue(object):
+ 
+ 
+ class MetricLogger(object):
+-    def __init__(self, delimiter="\t"):
++    def __init__(self, delimiter="\t", flops=0):
+         self.meters = defaultdict(SmoothedValue)
+         self.delimiter = delimiter
++        self.flops = flops
+ 
+     def update(self, **kwargs):
+         for k, v in kwargs.items():
+@@ -127,16 +127,26 @@ class MetricLogger(object):
+             'eta: {eta}',
+             '{meters}',
+             'time: {time}',
+-            'data: {data}'
++            'data: {data}',
++            'throughput: {throughput}',
++            'tflops: {tflops:.2f}'
+         ]
+         if torch.cuda.is_available():
+             log_msg.append('max mem: {memory:.0f}')
++
+         log_msg = self.delimiter.join(log_msg)
+         MB = 1024.0 * 1024.0
++
+         for obj in iterable:
+             data_time.update(time.time() - end)
+             yield obj
++
++            batch_size = obj[0].shape[0]
+             iter_time.update(time.time() - end)
++            throughput = int(batch_size / iter_time.value)
++            # First mutiply by 3: 1 for forward, 2 for backward. Then multiply by 2: 1MACs = 2FLOPs
++            tflops = 3 * 2 * self.flops * throughput / 1e12
++
+             if i % print_freq == 0 or i == len(iterable) - 1:
+                 eta_seconds = iter_time.global_avg * (len(iterable) - i)
+                 eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
+@@ -145,7 +155,10 @@ class MetricLogger(object):
+                         i, len(iterable), eta=eta_string,
+                         meters=str(self),
+                         time=str(iter_time), data=str(data_time),
+-                        memory=torch.cuda.max_memory_allocated() / MB))
++                        throughput=throughput,
++                        tflops=tflops,
++                        memory=torch.cuda.max_memory_allocated() / MB,
++                        ))
+                 else:
+                     print(log_msg.format(
+                         i, len(iterable), eta=eta_string,

--- a/deit/deit.patch
+++ b/deit/deit.patch
@@ -1,5 +1,5 @@
 diff --git a/engine.py b/engine.py
-index ed10cea..9fb4dd5 100644
+index ed10cea..ccc33e2 100644
 --- a/engine.py
 +++ b/engine.py
 @@ -15,6 +15,9 @@ from timm.utils import accuracy, ModelEma
@@ -17,7 +17,7 @@ index ed10cea..9fb4dd5 100644
                      set_training_mode=True, args = None):
      model.train(set_training_mode)
 -    metric_logger = utils.MetricLogger(delimiter="  ")
-+    metric_logger = utils.MetricLogger(delimiter="  ", flops=args.flops)
++    metric_logger = utils.MetricLogger(delimiter="  ", model_flops=args.model_flops)
      metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value:.6f}'))
      header = 'Epoch: [{}]'.format(epoch)
      print_freq = 10
@@ -72,7 +72,7 @@ index ed10cea..9fb4dd5 100644
              loss = criterion(output, target)
  
 diff --git a/main.py b/main.py
-index bc8c418..98de2a9 100644
+index bc8c418..75fce85 100644
 --- a/main.py
 +++ b/main.py
 @@ -15,7 +15,9 @@ from timm.models import create_model
@@ -122,20 +122,22 @@ index bc8c418..98de2a9 100644
      if True:  # args.distributed:
          num_tasks = utils.get_world_size()
          global_rank = utils.get_rank()
-@@ -266,6 +283,12 @@ def main(args):
+@@ -266,6 +283,14 @@ def main(args):
          img_size=args.input_size
      )
  
-+    input = first_image.unsqueeze(0)
-+    flops = FlopCountAnalysis(model, input).total()
-+    args.flops = flops
++    input = first_image.unsqueeze(0).cuda()
++    model_flops = FlopCountAnalysis(model.cuda(), input).total()
++
++    args.model_flops = model_flops
++    print(f"model flops: {model_flops}")
 +
 +    if args.enable_msamp or args.enable_te_fp8:
 +        model.head.use_fp32_linear = True
                      
      if args.finetune:
          if args.finetune.startswith('https'):
-@@ -336,17 +359,33 @@ def main(args):
+@@ -336,17 +361,33 @@ def main(args):
              device='cpu' if args.model_ema_force_cpu else '',
              resume='')
  
@@ -174,7 +176,7 @@ index bc8c418..98de2a9 100644
  
      lr_scheduler, _ = create_scheduler(args, optimizer)
  
-@@ -406,7 +445,7 @@ def main(args):
+@@ -406,7 +447,7 @@ def main(args):
                  loss_scaler.load_state_dict(checkpoint['scaler'])
          lr_scheduler.step(args.start_epoch)
      if args.eval:
@@ -183,7 +185,7 @@ index bc8c418..98de2a9 100644
          print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
          return
  
-@@ -434,13 +473,13 @@ def main(args):
+@@ -434,13 +475,13 @@ def main(args):
                      'optimizer': optimizer.state_dict(),
                      'lr_scheduler': lr_scheduler.state_dict(),
                      'epoch': epoch,
@@ -199,7 +201,7 @@ index bc8c418..98de2a9 100644
          print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
          
          if max_accuracy < test_stats["acc1"]:
-@@ -453,7 +492,7 @@ def main(args):
+@@ -453,7 +494,7 @@ def main(args):
                          'optimizer': optimizer.state_dict(),
                          'lr_scheduler': lr_scheduler.state_dict(),
                          'epoch': epoch,
@@ -272,7 +274,7 @@ index 0000000..dba0819
 +        self._scaler.load_state_dict(state_dict)
 \ No newline at end of file
 diff --git a/utils.py b/utils.py
-index d1064f6..67d02eb 100644
+index d1064f6..e96ca83 100644
 --- a/utils.py
 +++ b/utils.py
 @@ -14,7 +14,6 @@ import datetime
@@ -288,14 +290,14 @@ index d1064f6..67d02eb 100644
  
  class MetricLogger(object):
 -    def __init__(self, delimiter="\t"):
-+    def __init__(self, delimiter="\t", flops=0):
++    def __init__(self, delimiter="\t", model_flops=0):
          self.meters = defaultdict(SmoothedValue)
          self.delimiter = delimiter
-+        self.flops = flops
++        self.model_flops = model_flops
  
      def update(self, **kwargs):
          for k, v in kwargs.items():
-@@ -127,16 +127,26 @@ class MetricLogger(object):
+@@ -127,16 +127,27 @@ class MetricLogger(object):
              'eta: {eta}',
              '{meters}',
              'time: {time}',
@@ -316,14 +318,15 @@ index d1064f6..67d02eb 100644
 +
 +            batch_size = obj[0].shape[0]
              iter_time.update(time.time() - end)
-+            throughput = int(batch_size / iter_time.value)
++            throughput_per_gpu = int(batch_size / iter_time.value)
++            throughput = throughput_per_gpu * get_world_size()
 +            # First mutiply by 3: 1 for forward, 2 for backward. Then multiply by 2: 1MACs = 2FLOPs
-+            tflops = 3 * 2 * self.flops * throughput / 1e12
++            tflops = 3 * 2 * self.model_flops * throughput_per_gpu / 1e12
 +
              if i % print_freq == 0 or i == len(iterable) - 1:
                  eta_seconds = iter_time.global_avg * (len(iterable) - i)
                  eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
-@@ -145,7 +155,10 @@ class MetricLogger(object):
+@@ -145,7 +156,10 @@ class MetricLogger(object):
                          i, len(iterable), eta=eta_string,
                          meters=str(self),
                          time=str(iter_time), data=str(data_time),

--- a/deit/deit.patch
+++ b/deit/deit.patch
@@ -1,5 +1,5 @@
 diff --git a/engine.py b/engine.py
-index ed10cea..76665ef 100644
+index ed10cea..9fb4dd5 100644
 --- a/engine.py
 +++ b/engine.py
 @@ -15,6 +15,9 @@ from timm.utils import accuracy, ModelEma
@@ -24,7 +24,7 @@ index ed10cea..76665ef 100644
  
 +    # amp_enable, fp8_enable, fp8_format='hybrid', max_history_len=1, amax_compute_algo='max'
 +    autocast_context = TeUtils.get_autocast(True, args.enable_te_fp8)
-+    
++
      for samples, targets in metric_logger.log_every(data_loader, print_freq, header):
          samples = samples.to(device, non_blocking=True)
          targets = targets.to(device, non_blocking=True)

--- a/deit/requirements.txt
+++ b/deit/requirements.txt
@@ -1,1 +1,2 @@
 timm==0.4.12
+fvcore


### PR DESCRIPTION
1. Add tflops and throughput in log for deit/Swin/RoBERTa.
2. Add a tool to print the  nvlink and ib bandwidth. If we want to get the communication total metrics, we need to multiply the bandwidth with the elapsed time of iteration.
3. The tflops and throughput computation is in another PR https://github.com/Azure/MS-AMP-Examples/pull/14 
4. fairseq-hydra-train already supports distributed training, no need to use `python -m torch.distributed.launch`. It's a misuse of fairseq-hydra-train and will crash after 1 epoch.