### PR TITLE
Bug fix for MS-AMP v0.4.0

### DIFF
--- a/RoBERTa/prepare_wikitext.sh
+++ b/RoBERTa/prepare_wikitext.sh
@@ -10,8 +10,12 @@ then
     rm -rf data-bin
 fi
 
-wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip
-unzip wikitext-103-raw-v1.zip
+# wget https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip
+# unzip wikitext-103-raw-v1.zip
+
+wget https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz
+tar -zxvf wikitext-103.tar.gz && mv wikitext-103 wikitext-103-raw
+
 
 mkdir -p gpt2_bpe
 wget -O gpt2_bpe/encoder.json https://dl.fbaipublicfiles.com/fairseq/gpt2_bpe/encoder.json
@@ -23,7 +27,7 @@ for SPLIT in train valid test; do \
     python -m examples.roberta.multiprocessing_bpe_encoder \
         --encoder-json gpt2_bpe/encoder.json \
         --vocab-bpe gpt2_bpe/vocab.bpe \
-        --inputs wikitext-103-raw/wiki.${SPLIT}.raw \
+        --inputs wikitext-103-raw/wiki.${SPLIT}.tokens \
         --outputs wikitext-103-raw/wiki.${SPLIT}.bpe \
         --keep-empty \
         --workers 60; \
@@ -41,4 +45,4 @@ fairseq-preprocess \
     --workers 60
 
 rm -rf gpt2_bpe
-rm -rf wikitext-103-raw*
+rm -rf wikitext-103*

--- a/Swin-Transformer/requirements.txt
+++ b/Swin-Transformer/requirements.txt
@@ -1,6 +1,6 @@
 
 timm==0.4.12
-opencv-python==4.4.0.46
+opencv-python==4.9.0.80
 termcolor==1.1.0
 yacs==0.1.8
 pyyaml

--- a/gpt3/pretrain_13b_megatron_ds.sh
+++ b/gpt3/pretrain_13b_megatron_ds.sh
@@ -22,7 +22,7 @@ MASTER_PORT=6001
 DATA_PATH=$PWD/data/wikipedia_text_document
 DATA_PATH=$PWD/data/wikipedia_text_document
 DATASET="1.0 ${DATA_PATH}"
-BS=4 
+BS=4
 PP=1
 TP=2
 CLIP_GRAD=1.0
@@ -116,7 +116,7 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 if [ "$FP_TYPE" = "bf16" ]; then
   echo "run 13b GPT3 with bf16"
   CHECKPOINT_PATH=$PWD/checkpoints/gpt_13b_bf16
-  python -m torch.distributed.launch $DISTRIBUTED_ARGS \
+  torchrun $DISTRIBUTED_ARGS \
     ../third_party/Megatron-DeepSpeed/pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \
@@ -127,7 +127,7 @@ if [ "$FP_TYPE" = "bf16" ]; then
 elif [ "$FP_TYPE" = "msamp" ]; then
   echo "run 13b GPT3 with msamp"
   CHECKPOINT_PATH=$PWD/checkpoints/gpt_13b_msamp
-  python -m torch.distributed.launch $DISTRIBUTED_ARGS \
+  torchrun $DISTRIBUTED_ARGS \
     ../third_party/Megatron-DeepSpeed/pretrain_gpt.py \
     $GPT_ARGS \
     $DATA_ARGS \


### PR DESCRIPTION
Fix 2 bugs when using msamp v.0.4:
- Use `torchrun` instead of `python -m torch.distributed.launch` in gpt3/pretrain_13b_megatron_ds.sh
- The download url of  Wikitext-103(https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip) is broken, change to https://dax-cdn.cdn.appdomain.cloud/dax-wikitext-103/1.0.1/wikitext-103.tar.gz
- Update opencv-python to latest version since old version can't install in latest MS-AMP docker